### PR TITLE
Change default bind address to the unspecified address 0.0.0.0

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -259,7 +259,7 @@ impl RpcDht {
             socket
         } else {
             UdpSocket::bind(SocketAddr::V4(SocketAddrV4::new(
-                Ipv4Addr::new(127, 0, 0, 1),
+                Ipv4Addr::new(0, 0, 0, 0),
                 0,
             )))
             .await?


### PR DESCRIPTION
The default bind address is currently 127.0.0.1, which means we always use the loopback device and cannot connect to a remote host unless we pass in a socket / bind address in the config.

For me, this means the [hyperswarm-rs hyperchat example](https://github.com/datrs/hyperswarm-rs/blob/main/examples/hyperchat.rs) will not work when the given bootstrap node is a remote host, even if we pass in a non-loopback ip using the `--bind` option, as this option is used only to configure tcp / utp connections to peers, not where to bind the dht node.

I think the default bind address should be the unspecified address (0.0.0.0) as this gives most flexibility - we can still use localhost for testing and also connect to remote hosts.